### PR TITLE
Add CGVector type

### DIFF
--- a/Sources/OpenCoreGraphics/CGVector.swift
+++ b/Sources/OpenCoreGraphics/CGVector.swift
@@ -1,0 +1,41 @@
+//
+//  CGVector.swift
+//  OpenCoreGraphics
+
+public import Foundation
+
+// MARK: - CGVector
+
+public struct CGVector: Equatable, Sendable {
+    public init() {
+        dx = .zero
+        dy = .zero
+    }
+
+    public init(dx: CGFloat, dy: CGFloat) {
+        self.dx = dx
+        self.dy = dy
+    }
+
+    public var dx: CGFloat
+    public var dy: CGFloat
+
+    public static let zero = CGVector()
+}
+
+// MARK: - Hashable
+
+extension CGVector: Swift.Hashable {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(dx)
+        hasher.combine(dy)
+    }
+}
+
+// MARK: - CustomDebugStringConvertible
+
+extension CGVector: Swift.CustomDebugStringConvertible {
+    public var debugDescription: String {
+        "(\(dx.description), \(dy.description))"
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CGVector` struct with `dx`/`dy` properties matching Darwin's CoreGraphics API
- Conform to `Equatable`, `Sendable`, `Hashable`, and `CustomDebugStringConvertible`

## Test plan
- [x] Verify build succeeds locally
- [ ] CI passes on all platforms (macOS, Linux)